### PR TITLE
Make separator configurable

### DIFF
--- a/attributor-flatpack.gemspec
+++ b/attributor-flatpack.gemspec
@@ -1,9 +1,8 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'attributor/flatpack/version'
 
-Gem::Specification.new do |spec|
+Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.name = 'attributor-flatpack'
   spec.version = Attributor::Flatpack::VERSION
   spec.authors = ['Dane Jensen']
@@ -22,14 +21,15 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'attributor', '>= 5'
   spec.add_development_dependency 'bundler', '~> 1.11'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rspec-its'
+  spec.add_development_dependency 'codeclimate-test-reporter'
   spec.add_development_dependency 'fuubar', '~> 2'
   spec.add_development_dependency 'guard'
   spec.add_development_dependency 'guard-rspec'
   spec.add_development_dependency 'guard-rubocop'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rspec-its'
   spec.add_development_dependency 'simplecov'
 end

--- a/benchmark/Gemfile
+++ b/benchmark/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
-gem 'benchmark-ips'
 gem 'attributor-flatpack', path: '../'
+gem 'benchmark-ips'

--- a/benchmark/bench.rb
+++ b/benchmark/bench.rb
@@ -43,7 +43,7 @@ poro = Poro.new(HOME, PATH)
 
 puts RUBY_DESCRIPTION
 
-Benchmark.ips do |x|
+Benchmark.ips do |x| # rubocop:disable Metrics/BlockLength
   x.report 'constants' do |i|
     i.times do
       HOME == PATH

--- a/examples/sample_config.rb
+++ b/examples/sample_config.rb
@@ -3,7 +3,7 @@ require 'bundler/setup'
 require 'pry'
 require 'pry-byebug'
 
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'attributor/flatpack'
 
 class SampleConfig < Attributor::Flatpack::Config

--- a/lib/attributor/flatpack/config.rb
+++ b/lib/attributor/flatpack/config.rb
@@ -1,15 +1,16 @@
 module Attributor
   module Flatpack
     class Config < Attributor::Hash
-      DEFAULT_SEPARATOR = '_'
+      DEFAULT_SEPARATOR = '_'.freeze
       @key_type = Symbol
 
       class << self
-        def separator(sep=nil)
+        def separator(sep = nil)
           return @separator unless sep
+
           @separator = sep
         end
-      end      
+      end
 
       def self.inherited(klass)
         super
@@ -46,10 +47,10 @@ module Attributor
           get(name, attribute: attribute, context: context)
         end
 
-        if attribute.type == Attributor::Boolean
-          define_singleton_method(name.to_s + '?') do
-            !!get(name, attribute: attribute, context: context)
-          end
+        return unless attribute.type == Attributor::Boolean
+
+        define_singleton_method(name.to_s + '?') do
+          !!get(name, attribute: attribute, context: context)
         end
       end
 
@@ -100,7 +101,7 @@ module Attributor
         return @raw[key] if @raw.key?(key)
 
         _found_key, found_value = @raw.find do |(k, _v)|
-          k.to_s.casecmp(key.to_s) == 0
+          k.to_s.casecmp(key.to_s).zero?
         end
 
         return found_value if found_value
@@ -119,12 +120,12 @@ module Attributor
         ::Hash[selected]
       end
 
-      def [](k)
-        get k
+      def [](key)
+        get key
       end
 
-      def []=(k, v)
-        set k, v
+      def []=(key, val)
+        set key, val
       end
 
       def merge!(other)

--- a/spec/attributor/flatpack/config_spec.rb
+++ b/spec/attributor/flatpack/config_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Attributor::Flatpack::Config do
+describe Attributor::Flatpack::Config do # rubocop:disable Metrics/BlockLength
   let(:type) do
     Class.new(Attributor::Flatpack::Config) do
       keys do
@@ -81,7 +81,7 @@ describe Attributor::Flatpack::Config do
       expect(config.widget_factory).to eq 'Factory of Widgets'
     end
   end
-  
+
   context 'merging names' do
     let(:data) do
       {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 require 'simplecov'
 SimpleCov.start
 
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'attributor/flatpack'
 
 require 'rspec/its'


### PR DESCRIPTION
* a `separator` DSL can be used on a per config basis
* or the default can be changed by redefining `Attributor::Flatpack::Config.DEFAULT_SEPARATOR`