### PR TITLE
Fix regexp for `Config#subselect` not escaping the separator and not …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # attributor-flatpack changelog
 
+## 1.4.1
+
+- Fix regexp for `Config#subselect` not escaping the separator and not matching properly
+
 ## 1.4
 
 - Respect `allow_extra: true` option when validating.

--- a/lib/attributor/flatpack/config.rb
+++ b/lib/attributor/flatpack/config.rb
@@ -121,7 +121,7 @@ module Attributor
       end
 
       def subselect(prefix)
-        prefix_match = /^#{prefix}#{self.class.separator}?(.*)/i
+        prefix_match = /^#{prefix}#{::Regexp.escape(self.class.separator)}(.*)/i
 
         selected = @raw.collect do |(k, v)|
           if (match = prefix_match.match(k))


### PR DESCRIPTION
…matching properly