### PR TITLE
validate the data before initializing config to fail fast

### DIFF
--- a/lib/attributor/flatpack/config.rb
+++ b/lib/attributor/flatpack/config.rb
@@ -37,7 +37,19 @@ module Attributor
         example
       end
 
+      def self.validate_data(data)
+        return true unless data.respond_to?(:keys)
+
+        data.keys.each do |k|
+          /(.)*/.match?(k)
+        rescue TypeError => e
+          raise ArgumentError, 'keys must be symboles or strings'
+        end
+      end
+
       def initialize(data = nil)
+        self.class.validate_data data
+
         @raw = data
         @contents = {}
 
@@ -171,7 +183,7 @@ module Attributor
 
       def validate_keys(context)
         return [] if self.class.options[:allow_extra]
-
+        
         errors = (@raw.keys.collect(&:to_s) - self.class.keys.keys.collect(&:to_s)).collect do |extra_key|
           "Unknown key received: #{extra_key.inspect} for #{Attributor.humanize_context(context)}"
         end

--- a/spec/attributor/flatpack/config_spec.rb
+++ b/spec/attributor/flatpack/config_spec.rb
@@ -240,4 +240,16 @@ describe Attributor::Flatpack::Config do
       it { should_not be_empty }
     end
   end
+
+  context 'with data with invalid keys' do
+    let(:data) do
+      {
+        { foo: :baz } => :bar
+        :foo => :bar
+      }
+    end
+    it 'should fail to initialize' do
+      expect { subject }.to raise_error(ArgumentError)
+    end
+  end
 end


### PR DESCRIPTION
Config relies on keys being string or symbol (it passes them to Regex#match) but does not validate the input on initialization. So you can initialize it with `{ { foo: :bar } => :baz, foo: :baz }` and you only get an error while trying to `get(:foo)`.

I was not able to validate the input in any other reliable way. Things like `data.keys.all? Symbole || data.keys.all? String` or `data.keys.all? { |k| k.instance_of?(Symbole) || k.instance_of?(String) }` did not work